### PR TITLE
Allow include directive to be used more safely

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,16 +19,17 @@ addons:
       - g++-5
 install:
   - sudo unlink /usr/bin/g++ && sudo ln -s /usr/bin/g++-5 /usr/bin/g++
-  - git clone --recursive git://github.com/apiaryio/drafter.git
-  - cd drafter
-  - git checkout v3.2.7
+  - wget https://github.com/apiaryio/drafter/releases/download/v3.2.7/drafter-v3.2.7.tar.gz
+  - tar xvzf drafter-v3.2.7.tar.gz
+  - cd drafter-v3.2.7
   - /usr/bin/python2.7 configure --shared
   - make libdrafter
   - sudo cp build/out/Release/lib.target/libdrafter.so /usr/lib/libdrafter.so
   - sudo mkdir -p /usr/include/drafter
   - sudo cp src/drafter.h /usr/include/drafter/drafter.h
   - cd ..
-  - rm -rf drafter/
+  - rm -rf drafter-v3.2.7/
+  - rm drafter-v3.2.7.tar.gz
   - python setup.py install
   - pip install --upgrade pip
   - pip install -r testing_requirements.txt

--- a/README.md
+++ b/README.md
@@ -10,8 +10,9 @@ Render API Blueprints on-the-fly using Django templates
 1. `django-apiblueprint-view` uses the [Drafter](https://github.com/apiaryio/drafter) C library for API Blueprint parsing. Install it using:
 
 ```
-git clone --recursive git://github.com/apiaryio/drafter.git
-cd drafter
+wget https://github.com/apiaryio/drafter/releases/download/v3.2.7/drafter-v3.2.7.tar.gz
+tar xvzf drafter-v3.2.7.tar.gz
+cd drafter-v3.2.7
 ./configure --shared
 make libdrafter
 sudo cp build/out/Release/lib.target/libdrafter.so /usr/lib/libdrafter.so

--- a/README.md
+++ b/README.md
@@ -124,6 +124,8 @@ You can include other files in your blueprint by using an include directive with
 
 This syntax is not a part of the API Blueprint spec, but is also supported in some other tools e.g: [aglio](https://github.com/danielgtaylor/aglio#including-files).
 
+The include directive has the potential to introduce remote file inclusion or directory traversal vulnerabilities if your application renders user-supplied content. There are a couple of settings to help mitigate this. Set `APIBP_PROCESS_INCLUDES = False` in your django settings to completely ignore include directives (the default is `True`). There is also a whitelist of allowed file types to include. The default whitelist is `['.md', '.apibp', '.json']` but this can be overridden by setting `APIBP_INCLUDE_WHITELIST` to a list of allowed extensions in your django settings.
+
 ## Licensing
 
 `django-apiblueprint-view` is made available under the MIT License

--- a/apiblueprint_view/parser.py
+++ b/apiblueprint_view/parser.py
@@ -3,6 +3,7 @@ import markdown2
 import os
 import re
 from django.conf import settings
+from django.utils._os import safe_join
 from draughtsman import parse
 
 
@@ -56,7 +57,7 @@ class ApibpParser:
     def _replace_includes(self, apibp):
         matches = re.findall(r'<!-- include\((.*)\) -->', apibp)
         for match in matches:
-            include_path = os.path.join(os.path.dirname(self.blueprint), match)
+            include_path = safe_join(os.path.dirname(self.blueprint), match)
 
             # recursively replace any includes in child files
             include_apibp = self._replace_includes(

--- a/apiblueprint_view/parser.py
+++ b/apiblueprint_view/parser.py
@@ -2,6 +2,7 @@ import copy
 import markdown2
 import os
 import re
+from django.conf import settings
 from draughtsman import parse
 
 
@@ -16,6 +17,8 @@ class ApibpParser:
         self.blueprint = os.path.abspath(blueprint)
         self.api = None
         self.host = None
+        self.process_includes = getattr(
+            settings, 'APIBP_PROCESS_INCLUDES', True)
 
     def _set_host(self):
         for element in self.api.content[0].attributes['meta']:
@@ -85,7 +88,9 @@ class ApibpParser:
                     pass
 
     def parse(self):
-        apibp = self._replace_includes(open(self.blueprint, 'r').read())
+        apibp = open(self.blueprint, 'r').read()
+        if self.process_includes:
+            apibp = self._replace_includes(apibp)
         self.api = parse(apibp)
         self._set_host()
         self._post_process(self.api[0])

--- a/apiblueprint_view/tests/base.py
+++ b/apiblueprint_view/tests/base.py
@@ -28,3 +28,15 @@ class ApibpTest(TestCase):
             "\n".join([x.strip() for x in needle_formatted.split("\n")]),
             "\n".join([x.strip() for x in haystack_formatted.split("\n")]),
         )
+
+    def assertNotInIgnoreFormatting(self, needle, haystack):
+        # use bs4 to standardise the formatting of both chunks of html
+        needle_formatted = BeautifulSoup(needle, "html.parser").prettify()
+        haystack_formatted = BeautifulSoup(haystack, "html.parser").prettify()
+
+        # then strip the leading/trailing whitespace when we
+        # compare to account for indentation differences
+        self.assertNotIn(
+            "\n".join([x.strip() for x in needle_formatted.split("\n")]),
+            "\n".join([x.strip() for x in haystack_formatted.split("\n")]),
+        )

--- a/apiblueprint_view/tests/fixtures/child.md
+++ b/apiblueprint_view/tests/fixtures/child.md
@@ -1,0 +1,4 @@
+# GET /message
++ Response 200 (text/plain)
+
+        Hello World!

--- a/apiblueprint_view/tests/fixtures/parent.md
+++ b/apiblueprint_view/tests/fixtures/parent.md
@@ -1,0 +1,9 @@
+FORMAT: 1A
+
+# API Title
+
+some text
+
+## API Endpoint
+
+<!-- include(child.md) -->

--- a/apiblueprint_view/tests/fixtures/suspicious.md
+++ b/apiblueprint_view/tests/fixtures/suspicious.md
@@ -1,0 +1,9 @@
+FORMAT: 1A
+
+# API Title
+
+some text
+
+## API Endpoint
+
+<!-- include(/etc/passwd) -->

--- a/apiblueprint_view/tests/test_includes.py
+++ b/apiblueprint_view/tests/test_includes.py
@@ -1,0 +1,43 @@
+from .base import ApibpTest
+
+
+response_body = """
+<div class="api-action-body">
+  Body:
+  <pre><code>Hello World!
+</code></pre>
+</div>"""
+
+comment = "<!-- include(child.md) -->"
+
+
+class IncludesTest(ApibpTest):
+
+    def test_include_no_setting(self):
+        response = self.get_response(
+            'apiblueprint_view/tests/fixtures/parent.md')
+        self.assertEqual(response.status_code, 200)
+        html = self.get_html(response)
+
+        self.assertInIgnoreFormatting(response_body, html)
+        self.assertNotInIgnoreFormatting(comment, html)
+
+    def test_include_setting_on(self):
+        with self.settings(APIBP_PROCESS_INCLUDES=True):
+            response = self.get_response(
+                'apiblueprint_view/tests/fixtures/parent.md')
+            self.assertEqual(response.status_code, 200)
+            html = self.get_html(response)
+
+            self.assertInIgnoreFormatting(response_body, html)
+            self.assertNotInIgnoreFormatting(comment, html)
+
+    def test_include_setting_off(self):
+        with self.settings(APIBP_PROCESS_INCLUDES=False):
+            response = self.get_response(
+                'apiblueprint_view/tests/fixtures/parent.md')
+            self.assertEqual(response.status_code, 200)
+            html = self.get_html(response)
+
+            self.assertNotInIgnoreFormatting(response_body, html)
+            self.assertInIgnoreFormatting(comment, html)

--- a/apiblueprint_view/tests/test_includes.py
+++ b/apiblueprint_view/tests/test_includes.py
@@ -43,6 +43,11 @@ class IncludesTest(ApibpTest):
             self.assertNotInIgnoreFormatting(response_body, html)
             self.assertInIgnoreFormatting(comment, html)
 
-    def test_include_suspicious(self):
+    def test_include_suspicious_outside_project_dir(self):
         with self.assertRaises(SuspiciousFileOperation):
             self.get_response('apiblueprint_view/tests/fixtures/suspicious.md')
+
+    def test_include_suspicious_not_in_whitelist(self):
+        with self.settings(APIBP_INCLUDE_WHITELIST=['.apibp', '.json']):
+            with self.assertRaises(SuspiciousFileOperation):
+                self.get_response('apiblueprint_view/tests/fixtures/parent.md')

--- a/apiblueprint_view/tests/test_includes.py
+++ b/apiblueprint_view/tests/test_includes.py
@@ -1,3 +1,4 @@
+from django.core.exceptions import SuspiciousFileOperation
 from .base import ApibpTest
 
 
@@ -41,3 +42,7 @@ class IncludesTest(ApibpTest):
 
             self.assertNotInIgnoreFormatting(response_body, html)
             self.assertInIgnoreFormatting(comment, html)
+
+    def test_include_suspicious(self):
+        with self.assertRaises(SuspiciousFileOperation):
+            self.get_response('apiblueprint_view/tests/fixtures/suspicious.md')


### PR DESCRIPTION
Various improvements to address comments in issue #9:

* allow user to turn off processing includes
* use `safe_join` to ensure included files are inside project dir
* implement file extension whitelist for includes
* tests and docs (refs #8 )
* 52e1ea0 is not strictly related to this PR, but needed to get the build to pass

Think this probably strikes a sensible balance.. @symroe - any comments before I merge it?
