### PR TITLE
build a macosx wheel

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -16,8 +16,7 @@ jobs:
         env:
           CIBW_BEFORE_BUILD_LINUX: yum install -y wget && ./build-drafter.sh linux
           CIBW_BEFORE_BUILD_MACOS: ./build-drafter.sh mac
-          CIBW_BUILD: "cp38-manylinux_x86_64 cp38-macosx_arm64"
-          CIBW_ARCHS_MACOS: arm64
+          CIBW_BUILD: "cp38-manylinux_x86_64 cp38-macosx_x86_64"
           CIBW_BUILD_VERBOSITY: 3
         with:
           package-dir: .
@@ -30,18 +29,10 @@ jobs:
           python-version: 3.8
       - run: pip install --upgrade pip
 
-      # There are two things happening here
-      #
-      # 1. Poetry automatically assumes the most specific tag
+      # Poetry automatically assumes the most specific tag
       # but we don't actually need specific builds
       # for each python version (3.8, 3.9, etc).
       # We build one wheel then re-tag it as py3-none.
-      #
-      # 2. Cross-compiling wheels for arm and poetry based projects
-      # creates wheels with the wrong platform tag. They are tagged
-      # with the source platform, not the target, so the wheel
-      # manifest + filename will be x86_64 instead of arm64.
-      # We re-tag it as arm64 to fix this.
       - name: Fix wheel tags (linux)
         if: startsWith(matrix.os, 'ubuntu')
         run: |
@@ -51,7 +42,7 @@ jobs:
         if: startsWith(matrix.os, 'macos')
         run: |
           pip install wheel>=0.40.0
-          wheel tags --python-tag py3 --abi-tag none --platform-tag macosx_arm64 dist/*-macosx*.whl --remove
+          wheel tags --python-tag py3 --abi-tag none dist/*-macosx*.whl --remove
 
       # build sdist, only on linux
       - name: Install dependencies

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -5,7 +5,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: ['ubuntu-latest', 'macos-13-xlarge']
+        os: ['ubuntu-latest', 'macos-11']
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -5,7 +5,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: ['ubuntu-latest', 'macos-11']
+        os: ['ubuntu-latest', 'macos-13-xlarge']
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -3,7 +3,10 @@ on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: ['ubuntu-latest', 'macos-11']
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -11,34 +14,53 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.16.0
         env:
-          CIBW_BEFORE_BUILD: yum install -y wget && ./build-drafter.sh
-          CIBW_BUILD: "cp37-manylinux_x86_64"
+          CIBW_BEFORE_BUILD_LINUX: yum install -y wget && ./build-drafter.sh linux
+          CIBW_BEFORE_BUILD_MACOS: ./build-drafter.sh mac
+          CIBW_BUILD: "cp38-manylinux_x86_64 cp38-macosx_arm64"
+          CIBW_ARCHS_MACOS: arm64
+          CIBW_BUILD_VERBOSITY: 3
         with:
           package-dir: .
           output-dir: dist
           config-file: "pyproject.toml"
 
-      - name: Set up Python 3.7
+      - name: Set up Python 3.8
         uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: 3.8
       - run: pip install --upgrade pip
 
-      # Poetry automatically assumes the most specific tag
+      # There are two things happening here
+      #
+      # 1. Poetry automatically assumes the most specific tag
       # but we don't actually need specific builds
       # for each python version (3.8, 3.9, etc).
-      # We build one wheel then re-tag it as cp3.
-      - name: Fix wheel tags
+      # We build one wheel then re-tag it as py3-none.
+      #
+      # 2. Cross-compiling wheels for arm and poetry based projects
+      # creates wheels with the wrong platform tag. They are tagged
+      # with the source platform, not the target, so the wheel
+      # manifest + filename will be x86_64 instead of arm64.
+      # We re-tag it as arm64 to fix this.
+      - name: Fix wheel tags (linux)
+        if: startsWith(matrix.os, 'ubuntu')
         run: |
           pip install wheel>=0.40.0
-          wheel tags --python-tag py3 --abi-tag none dist/*.whl --remove
+          wheel tags --python-tag py3 --abi-tag none dist/*linux*.whl --remove
+      - name: Fix wheel tags (mac)
+        if: startsWith(matrix.os, 'macos')
+        run: |
+          pip install wheel>=0.40.0
+          wheel tags --python-tag py3 --abi-tag none --platform-tag macosx_arm64 dist/*-macosx*.whl --remove
 
-      # build sdist
+      # build sdist, only on linux
       - name: Install dependencies
+        if: startsWith(matrix.os, 'ubuntu')
         run:
           pip install poetry
           make install
       - name: Build sdist
+        if: startsWith(matrix.os, 'ubuntu')
         run: poetry build --format sdist
 
       - run: ls dist

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ help:
 	@grep '^\.PHONY' Makefile | cut -d' ' -f2- | tr ' ' '\n'
 
 build-drafter:
-	./build-drafter.sh
+	./build-drafter.sh linux
 
 format:
 	poetry run isort .

--- a/apiblueprint_view/__init__.py
+++ b/apiblueprint_view/__init__.py
@@ -2,9 +2,19 @@ import os
 
 from .draughtsman import Draughtsman
 
-_path = os.path.join(os.path.abspath(os.path.dirname(__file__)), "lib", "libdrafter.so")
+_path_linux = os.path.join(
+    os.path.abspath(os.path.dirname(__file__)), "lib", "libdrafter.so"
+)
+_path_mac = os.path.join(
+    os.path.abspath(os.path.dirname(__file__)), "lib", "libdrafter.dylib"
+)
 
 try:
     dm = Draughtsman()
 except OSError:
-    dm = Draughtsman(_path)
+    if os.path.isfile(_path_mac):
+        dm = Draughtsman(_path_mac)
+    elif os.path.isfile(_path_linux):
+        dm = Draughtsman(_path_linux)
+    else:
+        raise Exception("oh noes")

--- a/apiblueprint_view/__init__.py
+++ b/apiblueprint_view/__init__.py
@@ -17,4 +17,4 @@ except OSError:
     elif os.path.isfile(_path_linux):
         dm = Draughtsman(_path_linux)
     else:
-        raise Exception("oh noes")
+        raise Exception("Failed to load libdrafter")

--- a/build-drafter.sh
+++ b/build-drafter.sh
@@ -2,6 +2,13 @@
 
 set -euxo pipefail
 
+if [ $# -ne 1 ]; then
+    echo "Usage: $0 [mac|linux]"
+    exit 1
+fi
+
+platform="$1"
+
 wget https://github.com/apiaryio/drafter/releases/download/v3.2.7/drafter-v3.2.7.tar.gz
 tar xvzf drafter-v3.2.7.tar.gz
 cd drafter-v3.2.7
@@ -9,6 +16,10 @@ python2.7 configure --shared
 make libdrafter
 cd ..
 mkdir -p apiblueprint_view/lib
-cp drafter-v3.2.7/build/out/Release/lib.target/libdrafter.so ./apiblueprint_view/lib/libdrafter.so
+if [ "$platform" = "mac" ]; then
+    cp drafter-v3.2.7/build/out/Release/libdrafter.dylib ./apiblueprint_view/lib/libdrafter.dylib
+else
+    cp drafter-v3.2.7/build/out/Release/lib.target/libdrafter.so ./apiblueprint_view/lib/libdrafter.so
+fi
 rm -rf drafter-v3.2.7/
 rm drafter-v3.2.7.tar.gz

--- a/build-drafter.sh
+++ b/build-drafter.sh
@@ -12,11 +12,7 @@ platform="$1"
 wget https://github.com/apiaryio/drafter/releases/download/v3.2.7/drafter-v3.2.7.tar.gz
 tar xvzf drafter-v3.2.7.tar.gz
 cd drafter-v3.2.7
-if [ "$platform" = "mac" ]; then
-    python2.7 configure --shared --dest-cpu arm
-else
-    python2.7 configure --shared
-fi
+python2.7 configure --shared
 make libdrafter
 cd ..
 mkdir -p apiblueprint_view/lib

--- a/build-drafter.sh
+++ b/build-drafter.sh
@@ -12,7 +12,11 @@ platform="$1"
 wget https://github.com/apiaryio/drafter/releases/download/v3.2.7/drafter-v3.2.7.tar.gz
 tar xvzf drafter-v3.2.7.tar.gz
 cd drafter-v3.2.7
-python2.7 configure --shared
+if [ "$platform" = "mac" ]; then
+    python2.7 configure --shared --dest-cpu arm
+else
+    python2.7 configure --shared
+fi
 make libdrafter
 cd ..
 mkdir -p apiblueprint_view/lib

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-apiblueprint-view"
-version = "2.4.1"
+version = "2.5.0b1"
 description = "Render API Blueprints on-the-fly using Django templates"
 authors = ["chris48s"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,11 @@ classifiers = [
     "Framework :: Django :: 3",
     "Framework :: Django :: 4",
 ]
-include = ["apiblueprint_view/templates/**", "apiblueprint_view/lib/libdrafter.so"]
+include = [
+    "apiblueprint_view/templates/**",
+    "apiblueprint_view/lib/libdrafter.so",
+    "apiblueprint_view/lib/libdrafter.dylib"
+]
 exclude = ["apiblueprint_view/tests/**"]
 packages = [ {include = "apiblueprint_view"} ]
 build = "build.py"


### PR DESCRIPTION
Refs #181

OK, so this kinda works
In a way
Except it doesn't

What I am fundamentally doing here is

- spinning up a macos x86_64 runner (which is what GitHub actions gives you if you ask for a 'macos' runner
- compiling a macos x86_64 dylib
- creating a wheel which is tagged as arm64 in the metadata but actually has a x86_64 dylib in the wheel

This is.. not helpful :facepalm:

Native arm64 runners do exist, but I'm not allowed to use them yet (unless I pay).

![Screenshot at 2023-10-16 17-01-48](https://github.com/chris48s/django-apiblueprint-view/assets/6025893/309ae886-5dd6-4297-8ae6-14824448c628)

So I think the options are:

- put this on ice until plebs like me can use the native arm64 runners (at which point this may, or may not, work)
- figure out the cross-compilation bit myself (if that is even do-able, which it may not be https://github.com/apiaryio/drafter/blob/v3.2.7/configure#L40-L43 )
- publish a macos x86_64 wheel and see if mac users can run that using rosetta?

sigh