### PR TITLE
WIP test on python 3.13

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,11 +6,18 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
         django-version: ['>=2.2,<2.3', '>=3.2,<3.3', '>=4.0,<4.3', '>=5.0,<5.3']
         exclude:
           - python-version: '3.12'
             django-version: '>=2.2,<2.3'
+
+          - python-version: '3.13'
+            django-version: '>=2.2,<2.3'
+          - python-version: '3.13'
+            django-version: '>=3.2,<3.3'
+          - python-version: '3.13'
+            django-version: '>=4.0,<4.3'
 
           - python-version: '3.7'
             django-version: '>=4.0,<4.3'


### PR DESCRIPTION
Fails with

```
ImportError: /home/runner/.cache/pypoetry/virtualenvs/django-apiblueprint-view-bz5ChO0m-py3.13/lib/python3.13/site-packages/_cffi_backend.cpython-313-x86_64-linux-gnu.so: undefined symbol: _PyErr_WriteUnraisableMsg
```

There isn't yet a released version of cffi with a fix

https://github.com/python-cffi/cffi/issues/23